### PR TITLE
Add pkg requirements for clean/warn runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Steps to reproduce:
 
+- `python3 -m venv env && source env/bin/activate`
+- `pip3 install -r requirements_warn.txt`
 - `cd doc`
 - `doxygen ./Doxyfile`
 - `make html`
@@ -12,3 +14,5 @@ Potential matches:
 - void b(void *ptr, int (*comp)(void*, void*))
 
 ```
+
+Note that if package versions corresponding to `requirements_clean.txt` are installed (i.e. if `breathe <= 4.26.0`), then the `Unable to resolve function` warning is not produced.

--- a/requirements_clean.txt
+++ b/requirements_clean.txt
@@ -1,0 +1,3 @@
+sphinx
+breathe <= 4.26.0
+exhale

--- a/requirements_warn.txt
+++ b/requirements_warn.txt
@@ -1,0 +1,3 @@
+sphinx
+breathe > 4.26.0
+exhale


### PR DESCRIPTION
Adding these requirement files for easier demonstrations, particularly of `breathe`'s versioning.

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>